### PR TITLE
Update spelling and markdown formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Testing Go finace packages
+# Testing Go finance packages
 
 ## 1. finance-go
 
-Access to current and historical financial markets data in streamlined, well-formatted structures.
+Access to current and historical financial markets data in streamlined,
+well-formatted structures.
+
 Link: https://github.com/piquette/finance-go/tree/master
 
 ### Example
@@ -40,4 +42,5 @@ Link: https://github.com/achannarasappa/ticker
 ```
 
 ## Check out
+
 - [Go Awesome Quant](https://github.com/goex-top/awesome-go-quant)


### PR DESCRIPTION
* Fixed finace > finance in H1 header
* Split long markdown line across two lines (renders the same as expected)
* Moved piquette link to its own line to separate from paragraph (as already seen for a link in another section)
* Put whitespace after a header